### PR TITLE
New output buffer implementation

### DIFF
--- a/benches/benching.rs
+++ b/benches/benching.rs
@@ -93,6 +93,11 @@ fn parse_regex_benchmark(c: &mut Criterion) {
         let okkhor = Parser::new_regex();
         b.iter(|| okkhor.convert_regex(black_box(input1)));
     });
+    c.bench_function("okkhor regex a buf", |b| {
+        let okkhor = Parser::new_regex();
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| okkhor.convert_regex_into(black_box(input1), &mut buffer));
+    });
     c.bench_function("riti regex a", |b| {
         b.iter(|| regex::parse(black_box(input1)));
     });
@@ -101,6 +106,11 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     c.bench_function("okkhor regex bistari", |b| {
         let okkhor = Parser::new_regex();
         b.iter(|| okkhor.convert_regex(black_box(input2)));
+    });
+    c.bench_function("okkhor regex bistari buf", |b| {
+        let okkhor = Parser::new_regex();
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| okkhor.convert_regex_into(black_box(input2), &mut buffer));
     });
     c.bench_function("riti regex bistari", |b| {
         b.iter(|| regex::parse(black_box(input2)));
@@ -111,6 +121,11 @@ fn parse_regex_benchmark(c: &mut Criterion) {
         let okkhor = Parser::new_regex();
         b.iter(|| okkhor.convert_regex(black_box(input3)));
     });
+    c.bench_function("okkhor regex arO buf", |b| {
+        let okkhor = Parser::new_regex();
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| okkhor.convert_regex_into(black_box(input3), &mut buffer));
+    });
     c.bench_function("riti regex arO", |b| {
         b.iter(|| regex::parse(black_box(input3)));
     });
@@ -119,6 +134,11 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     c.bench_function("okkhor regex kkhet", |b| {
         let okkhor = Parser::new_regex();
         b.iter(|| okkhor.convert_regex(black_box(input4)));
+    });
+    c.bench_function("okkhor regex kkhet buf", |b| {
+        let okkhor = Parser::new_regex();
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| okkhor.convert_regex_into(black_box(input4), &mut buffer));
     });
     c.bench_function("riti regex kkhet", |b| {
         b.iter(|| regex::parse(black_box(input4)));

--- a/benches/benching.rs
+++ b/benches/benching.rs
@@ -101,6 +101,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     c.bench_function("riti regex a", |b| {
         b.iter(|| regex::parse(black_box(input1)));
     });
+    c.bench_function("riti regex a buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input1), &mut buffer));
+    });
 
     let input2 = "bistari";
     c.bench_function("okkhor regex bistari", |b| {
@@ -114,6 +118,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     });
     c.bench_function("riti regex bistari", |b| {
         b.iter(|| regex::parse(black_box(input2)));
+    });
+    c.bench_function("riti regex bistari buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input2), &mut buffer));
     });
 
     let input3 = "arO";
@@ -129,6 +137,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     c.bench_function("riti regex arO", |b| {
         b.iter(|| regex::parse(black_box(input3)));
     });
+    c.bench_function("riti regex arO buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input3), &mut buffer));
+    });
 
     let input4 = "kkhet";
     c.bench_function("okkhor regex kkhet", |b| {
@@ -142,6 +154,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     });
     c.bench_function("riti regex kkhet", |b| {
         b.iter(|| regex::parse(black_box(input4)));
+    });
+    c.bench_function("riti regex kkhet buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input4), &mut buffer));
     });
 }
 

--- a/benches/regex.rs
+++ b/benches/regex.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 #![allow(unused_assignments)]
 use std::cmp::Ordering;
 

--- a/benches/regex.rs
+++ b/benches/regex.rs
@@ -6,12 +6,18 @@ mod patterns;
 
 use patterns::{Scope, Type, CONSONANT, IGNORE, MAX_PATTERN_LEN, PATTERNS, VOWELS};
 
+pub(crate) fn parse(input: &str) -> String { 
+    let mut output = String::with_capacity(input.len() * 60);
+    parse_buf(input, &mut output);
+    output
+}
+
 /// Parse `input` string containing phonetic text and return a regex string.
-pub(crate) fn parse(input: &str) -> String {
+pub(crate) fn parse_buf(input: &str, output: &mut String) {
     let fixed = clean_string(input);
     let len = fixed.len();
 
-    let mut output = String::with_capacity(len * 60);
+    output.clear();
     output.push('^'); // Regex beginning mark.
 
     let mut cur = 0;
@@ -106,8 +112,8 @@ pub(crate) fn parse(input: &str) -> String {
                                 }
 
                                 if replace {
-                                    output += rule.replace;
-                                    output += "(্[যবম])?(্?)([ঃঁ]?)";
+                                    output.push_str(rule.replace);
+                                    output.push_str("(্[যবম])?(্?)([ঃঁ]?)");
                                     cur = (end - 1) as usize;
                                     matched = true;
                                     break;
@@ -120,8 +126,8 @@ pub(crate) fn parse(input: &str) -> String {
                         }
 
                         // Default
-                        output += pattern.replace;
-                        output += "(্[যবম])?(্?)([ঃঁ]?)";
+                        output.push_str(pattern.replace);
+                        output.push_str("(্[যবম])?(্?)([ঃঁ]?)");
                         cur = (end - 1) as usize;
                         matched = true;
                         break;
@@ -140,13 +146,11 @@ pub(crate) fn parse(input: &str) -> String {
         }
 
         if !matched {
-            output += &fixed[cur..cur + 1];
+            output.push_str(&fixed[cur..cur + 1]);
         }
         cur += 1;
     }
     output.push('$'); // Regex end mark.
-
-    output
 }
 
 fn clean_string(string: &str) -> String {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -93,7 +93,6 @@ impl Parser {
         }
     }
 
-    #[inline]
     pub(crate) fn find_pattern(&self, input: &str) -> Option<&Pattern> {
         self.patterns
             .range(..=input)
@@ -104,7 +103,6 @@ impl Parser {
 }
 
 impl Pattern {
-    #[inline]
     pub(crate) fn get_replacement(&self, input: &str, prefix: char) -> &str {
         if self.rules.is_empty() {
             self.default_replacement

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,12 +65,18 @@ impl Parser {
     }
 
     pub fn convert(&self, raw_input: &str) -> String {
+        let mut output = String::with_capacity(64);
+        self.convert_into(raw_input, &mut output);
+        output
+    }
+
+    pub fn convert_into(&self, raw_input: &str, output: &mut String) {
         let input: String = raw_input.chars().map(conditional_lowercase).collect();
 
         let mut prefix = ' ';
         let mut input = &input[0..];
-        let mut output = String::with_capacity(input.len() * 3);
 
+        output.clear();
         while !input.is_empty() {
             match self.find_pattern(input) {
                 Some(pattern) => {
@@ -85,8 +91,6 @@ impl Parser {
                 }
             }
         }
-
-        output
     }
 
     pub(crate) fn find_pattern(&self, input: &str) -> Option<&Pattern> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -93,6 +93,7 @@ impl Parser {
         }
     }
 
+    #[inline]
     pub(crate) fn find_pattern(&self, input: &str) -> Option<&Pattern> {
         self.patterns
             .range(..=input)
@@ -103,6 +104,7 @@ impl Parser {
 }
 
 impl Pattern {
+    #[inline]
     pub(crate) fn get_replacement(&self, input: &str, prefix: char) -> &str {
         if self.rules.is_empty() {
             self.default_replacement

--- a/src/regex_patterns.rs
+++ b/src/regex_patterns.rs
@@ -189,6 +189,12 @@ impl Parser {
     }
 
     pub fn convert_regex(&self, raw_input: &str) -> String {
+        let mut output = String::with_capacity(512);
+        self.convert_regex_into(raw_input, &mut output);
+        output
+    }
+
+    pub fn convert_regex_into(&self, raw_input: &str, output: &mut String) {
         const EXTRA: &str = "(্[যবম])?(্?)([ঃঁ]?)";
 
         let input: String = raw_input
@@ -199,8 +205,8 @@ impl Parser {
 
         let mut prefix = ' ';
         let mut input = &input[0..];
-        let mut output = String::with_capacity(input.len() * 60);
 
+        output.clear();
         output.push('^');
         while !input.is_empty() {
             match self.find_pattern(input) {
@@ -218,7 +224,5 @@ impl Parser {
             }
         }
         output.push('$');
-
-        output
     }
 }


### PR DESCRIPTION
Alongside previous APIs, new output buffer based APIs are implemented. It gives the API consumer the ability to pass an output buffer to put the output into.