### PR TITLE
Introduce output buffer based API to riti's regex code also to have a proper comparison

### DIFF
--- a/benches/benching.rs
+++ b/benches/benching.rs
@@ -101,6 +101,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     c.bench_function("riti regex a", |b| {
         b.iter(|| regex::parse(black_box(input1)));
     });
+    c.bench_function("riti regex a buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input1), &mut buffer));
+    });
 
     let input2 = "bistari";
     c.bench_function("okkhor regex bistari", |b| {
@@ -114,6 +118,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     });
     c.bench_function("riti regex bistari", |b| {
         b.iter(|| regex::parse(black_box(input2)));
+    });
+    c.bench_function("riti regex bistari buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input2), &mut buffer));
     });
 
     let input3 = "arO";
@@ -129,6 +137,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     c.bench_function("riti regex arO", |b| {
         b.iter(|| regex::parse(black_box(input3)));
     });
+    c.bench_function("riti regex arO buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input3), &mut buffer));
+    });
 
     let input4 = "kkhet";
     c.bench_function("okkhor regex kkhet", |b| {
@@ -142,6 +154,10 @@ fn parse_regex_benchmark(c: &mut Criterion) {
     });
     c.bench_function("riti regex kkhet", |b| {
         b.iter(|| regex::parse(black_box(input4)));
+    });
+    c.bench_function("riti regex kkhet buf", |b| {
+        let mut buffer = String::with_capacity(512);
+        b.iter(|| regex::parse_buf(black_box(input4), &mut buffer));
     });
 }
 

--- a/benches/regex.rs
+++ b/benches/regex.rs
@@ -6,12 +6,18 @@ mod patterns;
 
 use patterns::{Scope, Type, CONSONANT, IGNORE, MAX_PATTERN_LEN, PATTERNS, VOWELS};
 
+pub(crate) fn parse(input: &str) -> String { 
+    let mut output = String::with_capacity(input.len() * 60);
+    parse_buf(input, &mut output);
+    output
+}
+
 /// Parse `input` string containing phonetic text and return a regex string.
-pub(crate) fn parse(input: &str) -> String {
+pub(crate) fn parse_buf(input: &str, output: &mut String) {
     let fixed = clean_string(input);
     let len = fixed.len();
 
-    let mut output = String::with_capacity(len * 60);
+    output.clear();
     output.push('^'); // Regex beginning mark.
 
     let mut cur = 0;
@@ -106,8 +112,8 @@ pub(crate) fn parse(input: &str) -> String {
                                 }
 
                                 if replace {
-                                    output += rule.replace;
-                                    output += "(্[যবম])?(্?)([ঃঁ]?)";
+                                    output.push_str(rule.replace);
+                                    output.push_str("(্[যবম])?(্?)([ঃঁ]?)");
                                     cur = (end - 1) as usize;
                                     matched = true;
                                     break;
@@ -120,8 +126,8 @@ pub(crate) fn parse(input: &str) -> String {
                         }
 
                         // Default
-                        output += pattern.replace;
-                        output += "(্[যবম])?(্?)([ঃঁ]?)";
+                        output.push_str(pattern.replace);
+                        output.push_str("(্[যবম])?(্?)([ঃঁ]?)");
                         cur = (end - 1) as usize;
                         matched = true;
                         break;
@@ -140,13 +146,11 @@ pub(crate) fn parse(input: &str) -> String {
         }
 
         if !matched {
-            output += &fixed[cur..cur + 1];
+            output.push_str(&fixed[cur..cur + 1]);
         }
         cur += 1;
     }
     output.push('$'); // Regex end mark.
-
-    output
 }
 
 fn clean_string(string: &str) -> String {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -93,6 +93,7 @@ impl Parser {
         }
     }
 
+    #[inline]
     pub(crate) fn find_pattern(&self, input: &str) -> Option<&Pattern> {
         self.patterns
             .range(..=input)
@@ -103,6 +104,7 @@ impl Parser {
 }
 
 impl Pattern {
+    #[inline]
     pub(crate) fn get_replacement(&self, input: &str, prefix: char) -> &str {
         if self.rules.is_empty() {
             self.default_replacement


### PR DESCRIPTION
I tried to `inline` two functions, but it seems nothing changes much :disappointed: But I really don't know why  riti's regex gains speedup (should be noises) :rofl: 

Only on the `bistari` case `okkhor` has a great leap otherwise, it's behind the riti's implementation :disappointed: 

<pre>group                       with_inline                            without_inline
-----                       -----------                            --------------
okkhor ami<font color="#26A269"><b>                  1.00    275.2±3.53ns        ? ?/sec</b></font>    1.00    275.7±3.43ns        ? ?/sec
okkhor bistarito            1.03    727.4±7.90ns        ? ?/sec<font color="#26A269"><b>    1.00    705.3±7.59ns        ? ?/sec</b></font>
okkhor kormo<font color="#26A269"><b>                1.00    421.6±4.52ns        ? ?/sec</b></font>    1.00    421.5±4.58ns        ? ?/sec
okkhor long word            1.03    572.1±7.51ns        ? ?/sec<font color="#26A269"><b>    1.00    554.2±4.69ns        ? ?/sec</b></font>
okkhor new                  1.01     22.1±0.24µs        ? ?/sec<font color="#26A269"><b>    1.00     21.9±0.24µs        ? ?/sec</b></font>
okkhor regex a<font color="#26A269"><b>              1.00    116.0±1.33ns        ? ?/sec</b></font>    1.16    135.0±6.11ns        ? ?/sec
okkhor regex a buf<font color="#26A269"><b>          1.00     99.8±1.25ns        ? ?/sec</b></font>    1.05    104.8±1.26ns        ? ?/sec
okkhor regex arO<font color="#26A269"><b>            1.00    279.8±3.02ns        ? ?/sec</b></font>    1.00    280.7±3.97ns        ? ?/sec
okkhor regex arO buf        1.00    264.3±2.73ns        ? ?/sec<font color="#26A269"><b>    1.00    263.8±2.67ns        ? ?/sec</b></font>
okkhor regex bistari<font color="#26A269"><b>        1.00    619.5±6.89ns        ? ?/sec</b></font>    1.00    620.2±7.62ns        ? ?/sec
okkhor regex bistari buf<font color="#26A269"><b>    1.00    603.7±6.00ns        ? ?/sec</b></font>    1.00    604.7±6.47ns        ? ?/sec
okkhor regex kkhet<font color="#26A269"><b>          1.00    317.9±3.15ns        ? ?/sec</b></font>    1.02    323.8±3.58ns        ? ?/sec
okkhor regex kkhet buf<font color="#26A269"><b>      1.00    301.5±3.34ns        ? ?/sec</b></font>    1.02    308.8±3.77ns        ? ?/sec
okkhor sentence 1           1.01  1577.0±15.39ns        ? ?/sec<font color="#26A269"><b>    1.00  1554.0±21.81ns        ? ?/sec</b></font>
okkhor sentence 2           1.02      5.6±0.06µs        ? ?/sec<font color="#26A269"><b>    1.00      5.5±0.06µs        ? ?/sec</b></font>
okkhor sonar bangla         1.02  1410.1±14.47ns        ? ?/sec<font color="#26A269"><b>    1.00  1380.6±15.31ns        ? ?/sec</b></font>
riti regex a<font color="#26A269"><b>                1.00    155.5±1.87ns        ? ?/sec</b></font>    1.02    158.9±1.78ns        ? ?/sec
riti regex a buf<font color="#26A269"><b>            1.00     98.4±1.27ns        ? ?/sec</b></font>    1.02    100.6±1.25ns        ? ?/sec
riti regex arO<font color="#26A269"><b>              1.00    515.5±5.74ns        ? ?/sec</b></font>    1.00    516.8±5.80ns        ? ?/sec
riti regex arO buf<font color="#26A269"><b>          1.00    422.2±5.57ns        ? ?/sec</b></font>    1.01    427.0±4.32ns        ? ?/sec
riti regex bistari<font color="#26A269"><b>          1.00  1032.7±11.17ns        ? ?/sec</b></font>    1.05   1085.7±8.26ns        ? ?/sec
riti regex bistari buf<font color="#26A269"><b>      1.00  1013.4±12.77ns        ? ?/sec</b></font>    1.02  1037.0±15.75ns        ? ?/sec
riti regex kkhet<font color="#26A269"><b>            1.00    361.1±7.15ns        ? ?/sec</b></font>    1.06    382.9±4.00ns        ? ?/sec
riti regex kkhet buf<font color="#26A269"><b>        1.00    284.8±4.49ns        ? ?/sec</b></font>    1.03    294.1±3.18ns        ? ?/sec
rupantor ami                1.05  1444.4±17.74ns        ? ?/sec<font color="#26A269"><b>    1.00  1371.5±16.75ns        ? ?/sec</b></font>
rupantor bistarito          1.04      6.2±0.10µs        ? ?/sec<font color="#26A269"><b>    1.00      6.0±0.08µs        ? ?/sec</b></font>
rupantor kormo              1.04      2.8±0.03µs        ? ?/sec<font color="#26A269"><b>    1.00      2.7±0.03µs        ? ?/sec</b></font>
rupantor long word          1.04      4.7±0.06µs        ? ?/sec<font color="#26A269"><b>    1.00      4.5±0.04µs        ? ?/sec</b></font>
rupantor new                1.01    428.1±4.41µs        ? ?/sec<font color="#26A269"><b>    1.00    423.9±4.06µs        ? ?/sec</b></font>
rupantor sentence 1         1.05     14.7±0.18µs        ? ?/sec<font color="#26A269"><b>    1.00     14.1±0.23µs        ? ?/sec</b></font>
rupantor sentence 2         1.04     54.5±0.80µs        ? ?/sec<font color="#26A269"><b>    1.00     52.4±0.69µs        ? ?/sec</b></font>
rupantor sonar bangla       1.04     13.4±0.15µs        ? ?/sec<font color="#26A269"><b>    1.00     12.9±0.21µs        ? ?/sec</b></font>
</pre>

Can you run the benchmark from your side too?