### PR TITLE
filter then map is as efficient as filter_map

### DIFF
--- a/src/regex_patterns.rs
+++ b/src/regex_patterns.rs
@@ -198,7 +198,7 @@ impl Parser {
         let input: String = raw_input
             .chars()
             .filter(|c| !c.is_ascii_punctuation())
-            .map(char::to_ascii_lowercase)
+            .map(|c| c.to_ascii_lowercase())
             .collect();
 
         let mut prefix = ' ';

--- a/src/regex_patterns.rs
+++ b/src/regex_patterns.rs
@@ -197,13 +197,8 @@ impl Parser {
 
         let input: String = raw_input
             .chars()
-            .filter_map(|ch| {
-                if ch.is_ascii_punctuation() {
-                    None
-                } else {
-                    Some(ch.to_ascii_lowercase())
-                }
-            })
+            .filter(|c| !c.is_ascii_punctuation())
+            .map(char::to_ascii_lowercase)
             .collect();
 
         let mut prefix = ' ';


### PR DESCRIPTION
Rust uses lazy pull iterators. A `map` on a `filter` is as efficient as `filter_map`.

### Changes
- Replace `filter_map` in punctuation check for regex_patterns with `filter` then `map`
